### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/unflatten.js
+++ b/unflatten.js
@@ -10,6 +10,8 @@ function unflatten(obj = {}) {
     let m = {};
 
     while ((m = regex.exec(p))) {
+      if (curr[prop] === constructor.prototype)
+        curr[prop] = {}
       curr = curr[prop] || (curr[prop] = m[2] ? [] : {});
       prop = m[2] || m[1];
     }


### PR DESCRIPTION
### :bar_chart: Metadata *

`arr-flatten-unflatten` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-arr-flatten-unflatten

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
var arrFlattenUnflatten = require("./")
console.log("Before : " + {}.polluted);
arrFlattenUnflatten.unflatten({'__proto__[polluted]': 'Yes! Its Polluted'});
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i arr-flatten-unflatten # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before: undefined
After: Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/104119221-0b7c8400-5354-11eb-9189-aa4d6c540fa0.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
